### PR TITLE
Improve grammar rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,5 +1,5 @@
 const WHITE_SPACE = /[ \f\t\v]+/;
-const NEWLINE = /[\r?\n]/;
+const NEWLINE = /\r?\n/;
 const ANYTHING = /[^\r\n]+/;
 
 module.exports = grammar({
@@ -11,18 +11,26 @@ module.exports = grammar({
     source: ($) => repeat(choice($.evaluation_block, NEWLINE)),
 
     evaluation_block: ($) =>
-      prec.right(seq(repeat1($.prompt_line), optional(seq($.result, NEWLINE)))),
-
-    prompt_line: ($) => seq($.prompt, choice($.expression, NEWLINE)),
-
-    prompt: ($) =>
       seq(
-        choice("iex", "..."),
-        optional(seq(token.immediate(/\(\d+\)/))),
-        token.immediate(">")
+        alias($._default_prompt_line, $.prompt_line),
+        repeat(alias($._cont_prompt_line, $.prompt_line)),
+        optional($.result)
+      ),
+
+    _default_prompt_line: ($) =>
+      seq(
+        alias(/iex(\(\d+\))?>/, $.prompt),
+        optional($.expression)
+      ),
+
+    _cont_prompt_line: ($) =>
+      seq(
+        alias(/\.\.\.(\(\d+\))?>/, $.prompt),
+        optional($.expression)
       ),
 
     expression: ($) => seq(ANYTHING, NEWLINE),
+
     result: ($) => token(prec(-1, ANYTHING)),
   },
 });

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -23,7 +23,8 @@ iex>
 (source
   (evaluation_block
     (prompt_line
-      (prompt))
+      (prompt)))
+  (evaluation_block
     (prompt_line
       (prompt))))
 
@@ -40,7 +41,8 @@ iex> send self(), :hello
   (evaluation_block
     (prompt_line
       (prompt)
-      (expression))
+      (expression)))
+  (evaluation_block
     (prompt_line
       (prompt)
       (expression))))
@@ -82,7 +84,8 @@ iex(1)> System.otp_release()
   (evaluation_block
     (prompt_line
       (prompt)
-      (expression))
+      (expression)))
+  (evaluation_block
     (prompt_line
       (prompt)
       (expression))
@@ -106,7 +109,8 @@ iex(1)> quote do
       (expression))
     (prompt_line
       (prompt)
-      (expression))
+      (expression)))
+  (evaluation_block
     (prompt_line
       (prompt)
       (expression))


### PR DESCRIPTION
I think semantically this is two evaluation blocks:

```
iex> 1
iex> 2
```

While this is one:

```
iex> 1
...> 2
```

The `...>` prompt is always a continuation, so we can identify multiline expressions based on this.