### PR TITLE
Ignore bindings in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 /src/**/* linguist-generated=true
+/bindings/**/* linguist-generated=true


### PR DESCRIPTION
It's not much code, but more than the grammar, so still confusing :see_no_evil: 